### PR TITLE
Added Neon as accepted response to the lsb_release test

### DIFF
--- a/obs-install.sh
+++ b/obs-install.sh
@@ -185,6 +185,8 @@ fi
 OS_ID=$(lsb_release --id --short)
 if [ "${OS_ID}" == "Ubuntu" ]; then
   fancy_message info "Ubuntu detected."
+elif [ "${OS_ID}" == "Neon" ]; then
+  fancy_message info "KDE Neon detected."
 else
   fancy_message error "${OS_ID} is not supported."
 fi


### PR DESCRIPTION
KDE Neon is the GNU/Linux OS used by the KDE project, based on Ubuntu. This change adds "Neon" as an acceptable response when checking lsb_release. 

"Works on my machine." 